### PR TITLE
chore: upgrade deepgram-sdk to >=7.6.0

### DIFF
--- a/deepgram.toml
+++ b/deepgram.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/deepgram-starters/django-transcription"
 useCase = "transcription"
 language = "python"
 framework = "django"
-sdk = "6.0.0-rc.1"
+sdk = "deepgram-sdk"
 tags = ["transcription", "stt", "speech-to-text", "asr", "pre-recorded", "python", "django"]
 
 # Check prerequisites

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 channels==4.0.0
 daphne==4.1.0
-deepgram-sdk==6.0.0
+deepgram-sdk>=7.6.0
 django==5.0.0
 django-cors-headers==4.3.1
 PyJWT==2.10.1


### PR DESCRIPTION
## What
Standardize the Deepgram SDK dependency on `deepgram-sdk>=7.6.0` (was pinned to `6.0.0`). This repo already targets the v7 client surface, so this is a version bump with no code changes.

## How
- `requirements.txt`: `deepgram-sdk==6.0.0` -> `deepgram-sdk>=7.6.0`.
- `deepgram.toml`: `sdk = "6.0.0-rc.1"` -> `sdk = "deepgram-sdk"` (matches the `django-flux-tts` reference format).
- No application code changes: the prerecorded transcription REST calls (`client.listen.v1.media.transcribe_url` / `transcribe_file`) already uses the versioned v7 API with dict/kwarg options, so none of the renamed/removed v7 generated types apply.
- Runtime already meets the v7 minimum (`deploy/Dockerfile` uses `python:3.13-slim`, >= 3.10).

## Verified
- Python 3.14 venv, `pip install -r requirements.txt` (resolved `deepgram-sdk` 7.6.0).
- `python manage.py check` passes.
- `starter.views` imports cleanly and the REST method signatures bind with the kwargs used.
- Not run: a live end-to-end request against the Deepgram API (needs a real key).

## Manual verification needed before merge
- [ ] Live run with a real `DEEPGRAM_API_KEY`, end-to-end through the browser.
- [ ] Confirm the paired `*-html` frontend (git submodule) works unchanged.
